### PR TITLE
Fixed a TypeError bug

### DIFF
--- a/src/tokenize_all.py
+++ b/src/tokenize_all.py
@@ -124,9 +124,10 @@ class TokenizableLanguage:
             id_dict[identifier.type] = identifier
 
         # Reverse identifier dictionary so that arguments come first (and thus their regexs have priority)
-        self.identifiers = list(id_dict.values()).reverse()
-                    
+        self.identifiers = list(id_dict.values())
+        self.identifiers.reverse()
 
+        
     def tokenize(self, code) -> list[Token]:
         """
         Tokenizes the given code snippet into a `list` of `Tokens` using this `TokenizableLanguage`.


### PR DESCRIPTION
reverse() method doesn't return any value, when it is the last called method, it returns None rather a list.
This will cause `TypeError: unsupported operand type(s) for +: 'NoneType' and 'list'` in line 140: 
``` python
for identifier in self.identifiers + TokenizableLanguage.default_identifiers
        match = regex.match(identifier.regex, code)
```

So I just put this method in a new line and fixed this bug.